### PR TITLE
Update to AutoHotkey v2.0-beta.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tiny yet mighty convenient AutoHotkey v2 scripts
 
-For AutoHotkey v2.0-a122.
+For AutoHotkey v2.0-beta.1.
 See [installation instructions](#installation-instructions).
 
 - [The scripts](#the-scripts)
@@ -248,10 +248,10 @@ Illustrations minified with
 ## Installation instructions
 
 1. Download [AutoHotkey v2](https://www.autohotkey.com/v2/) (a zip file).
-   - The scripts are developed for v2.0-a122.
+   - The scripts are developed for v2.0-beta.1.
      Newer versions might also work
      since the scripts are very simple.
-2. Extract the zip file e.g. to `%programfiles%/AutoHotkey_2.0-a122/`.
+2. Extract the zip file e.g. to `%programfiles%/AutoHotkey_2.0-beta.1/`.
    - To open the `Program Files` folder,
      press <kbd>Ctrl</kbd> + <kbd>R</kbd>,
      type `%programfiles%` to the Run window,
@@ -265,7 +265,7 @@ Illustrations minified with
    - When opening an `.ahk` file for the first time,
      Windows should ask you
      what program to use to open the file.
-     Choose `AutoHotkeyU64.exe`
+     Choose `AutoHotkey64.exe`
      from the folder where you extracted the zip file.
 5. To run the scripts automatically
    when logging in to Windows,

--- a/scripts/pop-up_calendar.ahk
+++ b/scripts/pop-up_calendar.ahk
@@ -1,3 +1,4 @@
+#Requires AutoHotkey v2.0-beta.1
 #SingleInstance
 
 ;; AutoHotkey doesn't have nulls,

--- a/scripts/pop-up_calendar.ahk
+++ b/scripts/pop-up_calendar.ahk
@@ -1,5 +1,8 @@
 #SingleInstance
 
+;; AutoHotkey doesn't have nulls,
+;; so empty strings are often used to denote "nothing."
+;; https://lexikos.github.io/v2/docs/Concepts.htm#nothing
 global Calendar := ''
 
 ;; Win + c
@@ -10,19 +13,31 @@ global Calendar := ''
     ;; and to reset the date selection and window position
     DestroyCalendar()
 
-    Calendar := CreateCalendar()
+    CreateCalendar()
     Calendar.Show()
 }
 
-DestroyCalendar()
+;; The asterisk makes the function variadic,
+;; i.e. it accepts any number of parameters.
+;; We call it with 0 parameters,
+;; and GUI events call it with 1 parameter (the GUI object),
+;; so the function must be variadic or the script won't run.
+;; https://lexikos.github.io/v2/docs/Functions.htm#Variadic
+DestroyCalendar(*)
 {
-    SetTimer('UpdateTitle', 0)
-    (Calendar) && Calendar.Destroy()
+    SetTimer(UpdateTitle, 0)
+
+    global Calendar
+    if Calendar
+    {
+        Calendar.Destroy()
+        Calendar := ''
+    }
 }
 
 CreateCalendar()
 {
-    local Calendar := Gui.New('-MinimizeBox', GetTitle())
+    global Calendar := Gui('-MinimizeBox', GetTitle())
     Calendar.MarginX := -18
     Calendar.MarginY := -15
 
@@ -31,24 +46,21 @@ CreateCalendar()
     ;; W-4 = Show 4 columns
     Calendar.Add('MonthCal', '4 R3 W-4')
 
-    Calendar.OnEvent('Close', (*) => (
-        SetTimer('UpdateTitle', 0)
-    ))
+    Calendar.OnEvent('Close', DestroyCalendar)
+    Calendar.OnEvent('Escape', DestroyCalendar)
 
-    Calendar.OnEvent('Escape', (this) => (
-        this.Hide(),
-        SetTimer('UpdateTitle', 0)
-    ))
-
-    SetTimer('UpdateTitle', 100)
-
-    return Calendar
+    SetTimer(UpdateTitle, 100)
 }
 
 GetTitle()
 {
+    ;; En dash, not a hyphen
+    Prefix := 'Calendar – '
+
     ;; T0 = Show seconds
-    return 'Calendar – ' . FormatTime('T0', 'Time')
+    Time := FormatTime('T0', 'Time')
+
+    return Prefix . Time
 }
 
 UpdateTitle()


### PR DESCRIPTION
[AutoHotkey v2.0-beta.1 was released on 24 Jul 2021.](https://www.autohotkey.com/boards/viewtopic.php?f=24&t=93011)

Only `pop-up_calendar.ahk` needed changes. I fixed it and also clarified it a bit.

The other scripts didn't need any changes, so I added the [`#Requires` directive](https://lexikos.github.io/v2/docs/commands/_Requires.htm) only to the pop-up calendar script.

Some thoughts:

- Yay, first-class functions! `SetTimer('UpdateTitle', 0)` → `SetTimer(UpdateTitle, 0)`
- Global/local variables are now clearer.